### PR TITLE
feat(farms): add set_{min,max}_lock_duration_ms tx builders

### DIFF
--- a/src/packages/farms/api/farmsApi.ts
+++ b/src/packages/farms/api/farmsApi.ts
@@ -1607,6 +1607,63 @@ export class FarmsApi implements MoveErrorsInterface {
 	};
 
 	/**
+	 * Creates a transaction command to set the minimum lock duration (ms) for a
+	 * staking pool. Owner-cap only; V2 vault module. Mirrors
+	 * `setStakingPoolMinStakeAmountTxV2`.
+	 */
+	public setStakingPoolMinLockDurationMsTxV2 = (inputs: {
+		tx: Transaction;
+		ownerCapId: ObjectId;
+		stakingPoolId: ObjectId;
+		lockDurationMs: bigint;
+		stakeCoinType: CoinType;
+	}) => {
+		const { tx } = inputs;
+		return tx.moveCall({
+			target: Helpers.transactions.createTxTarget(
+				this.addresses.packages.vaultsV2,
+				FarmsApi.constants.moduleNames.vaultV2,
+				"set_min_lock_duration_ms"
+			),
+			typeArguments: [inputs.stakeCoinType],
+			arguments: [
+				tx.object(inputs.ownerCapId),
+				tx.object(inputs.stakingPoolId),
+				tx.object(this.addresses.objects.version),
+				tx.pure.u64(inputs.lockDurationMs),
+			],
+		});
+	};
+
+	/**
+	 * Creates a transaction command to set the maximum lock duration (ms) for a
+	 * staking pool. Owner-cap only; V2 vault module.
+	 */
+	public setStakingPoolMaxLockDurationMsTxV2 = (inputs: {
+		tx: Transaction;
+		ownerCapId: ObjectId;
+		stakingPoolId: ObjectId;
+		lockDurationMs: bigint;
+		stakeCoinType: CoinType;
+	}) => {
+		const { tx } = inputs;
+		return tx.moveCall({
+			target: Helpers.transactions.createTxTarget(
+				this.addresses.packages.vaultsV2,
+				FarmsApi.constants.moduleNames.vaultV2,
+				"set_max_lock_duration_ms"
+			),
+			typeArguments: [inputs.stakeCoinType],
+			arguments: [
+				tx.object(inputs.ownerCapId),
+				tx.object(inputs.stakingPoolId),
+				tx.object(this.addresses.objects.version),
+				tx.pure.u64(inputs.lockDurationMs),
+			],
+		});
+	};
+
+	/**
 	 * Creates a Move call (V1) to **remove undistributed reward coins** from a staking pool.
 	 * Only callable by the pool **owner** (validated via `ownerCapId`). This does not claw back
 	 * rewards already accrued/claimed by stakers—only reduces the remaining reward balance
@@ -2476,6 +2533,16 @@ export class FarmsApi implements MoveErrorsInterface {
 	public buildSetStakingPoolMinStakeAmountTxV2 =
 		Helpers.transactions.createBuildTxFunc(
 			this.setStakingPoolMinStakeAmountTxV2
+		);
+
+	public buildSetStakingPoolMinLockDurationMsTxV2 =
+		Helpers.transactions.createBuildTxFunc(
+			this.setStakingPoolMinLockDurationMsTxV2
+		);
+
+	public buildSetStakingPoolMaxLockDurationMsTxV2 =
+		Helpers.transactions.createBuildTxFunc(
+			this.setStakingPoolMaxLockDurationMsTxV2
 		);
 
 	/**

--- a/src/packages/farms/farmsStakingPool.ts
+++ b/src/packages/farms/farmsStakingPool.ts
@@ -451,6 +451,48 @@ export class FarmsStakingPool extends Caller {
 	}
 
 	/**
+	 * Builds a transaction to set the pool's minimum lock duration (ms).
+	 * Owner-cap only. V2 pools only — V1 vaults do not expose this entry.
+	 */
+	public getSetMinLockDurationMsTransaction(inputs: {
+		ownerCapId: ObjectId;
+		lockDurationMs: bigint;
+		walletAddress: SuiAddress;
+	}) {
+		if (this.version() === 1) {
+			throw new Error(
+				"set_min_lock_duration_ms is not supported on V1 staking pools"
+			);
+		}
+		return this.farmsApi().buildSetStakingPoolMinLockDurationMsTxV2({
+			...inputs,
+			stakeCoinType: this.stakingPool.stakeCoinType,
+			stakingPoolId: this.stakingPool.objectId,
+		});
+	}
+
+	/**
+	 * Builds a transaction to set the pool's maximum lock duration (ms).
+	 * Owner-cap only. V2 pools only.
+	 */
+	public getSetMaxLockDurationMsTransaction(inputs: {
+		ownerCapId: ObjectId;
+		lockDurationMs: bigint;
+		walletAddress: SuiAddress;
+	}) {
+		if (this.version() === 1) {
+			throw new Error(
+				"set_max_lock_duration_ms is not supported on V1 staking pools"
+			);
+		}
+		return this.farmsApi().buildSetStakingPoolMaxLockDurationMsTxV2({
+			...inputs,
+			stakeCoinType: this.stakingPool.stakeCoinType,
+			stakingPoolId: this.stakingPool.objectId,
+		});
+	}
+
+	/**
 	 * Builds a transaction granting a one-time admin cap to another address, allowing them to perform specific
 	 * one-time administrative actions (like initializing a reward).
 	 *


### PR DESCRIPTION
Adds V2-only Move-call builders and build* wrappers in FarmsApi, plus high-level getSetMinLockDurationMsTransaction / getSetMaxLockDurationMsTransaction methods on FarmsStakingPool. V1 pools throw a descriptive error. Mirrors the proven setStakingPoolMinStakeAmountTxV2 pattern exactly.