### PR TITLE
feat(auth): one cached T&C signature, move fields to request bodies

### DIFF
--- a/.changeset/afx-382-one-signed-message.md
+++ b/.changeset/afx-382-one-signed-message.md
@@ -1,0 +1,12 @@
+---
+"aftermath-ts-sdk": minor
+---
+
+Move to one cached Terms and Conditions signature (AFX-382)
+
+af-fe now verifies a single signed message in one place and no longer passes it to the services behind it. The message is the plain string `"Aftermath Terms and Conditions"`, signed once per session and reused everywhere.
+
+- `UserData.createTermsAndConditionsMessage()` (and `UserData.termsAndConditionsMessage`) returns that canonical string to sign. The old `createSignTermsAndConditionsMessageToSign()` (JSON `{action}`) is deprecated; the backend now rejects the wrapper with error 2034.
+- Fields that used to ride inside the per-action signed message now travel in the request body: `refCode` on `createReferralLink` (optional) and `setReferrer` (required); `orderObjectIds` on `cancelLimitOrder` and `closeDcaOrder`.
+- The per-action `...MessageToSign` helpers (referrals create/link, limit cancel, dca cancel) are deprecated.
+- `PerpetualsSponsorConfig.bytes`/`signature` now carry the cached T&C signature, and `walletAddress` must be the connected wallet (docs only; shape unchanged).

--- a/src/packages/dca/dca.ts
+++ b/src/packages/dca/dca.ts
@@ -176,15 +176,11 @@ export class Dca extends Caller {
 	 * The user can sign this message (converted to bytes) locally, then submit the signature to
 	 * `closeDcaOrder`.
 	 *
+	 * @deprecated af-fe no longer accepts this per-action message. Sign
+	 * `UserData.createTermsAndConditionsMessage` and pass `orderObjectIds` in the
+	 * `closeDcaOrder` body instead (AFX-382).
 	 * @param inputs - An object containing `orderIds`, an array of order object IDs to cancel.
 	 * @returns An object with `action: "CANCEL_DCA_ORDERS"` and the `order_object_ids`.
-	 *
-	 * @example
-	 * ```typescript
-	 * const msg = dca.closeDcaOrdersMessageToSign({ orderIds: ["0x<order1>", "0x<order2>"] });
-	 * console.log(msg);
-	 * // sign this as JSON or string-encode, then pass to closeDcaOrder
-	 * ```
 	 */
 	public closeDcaOrdersMessageToSign(inputs: { orderIds: ObjectId[] }): {
 		action: string;

--- a/src/packages/dca/dcaTypes.ts
+++ b/src/packages/dca/dcaTypes.ts
@@ -125,6 +125,11 @@ export interface ApiDcaTransactionForCloseOrderBody {
 	 * The user's signature corresponding to `bytes`.
 	 */
 	signature: string;
+	/**
+	 * The order object IDs to cancel. Required: the signed message no longer
+	 * carries them, so they must travel in the body (AFX-382).
+	 */
+	orderObjectIds: string[];
 }
 
 // =========================================================================

--- a/src/packages/limitOrders/limitOrders.ts
+++ b/src/packages/limitOrders/limitOrders.ts
@@ -168,16 +168,11 @@ export class LimitOrders extends Caller {
 	 * signs this message (converted to bytes), and the resulting signature is passed
 	 * to `cancelLimitOrder`.
 	 *
+	 * @deprecated af-fe no longer accepts this per-action message. Sign
+	 * `UserData.createTermsAndConditionsMessage` and pass `orderObjectIds` in the
+	 * `cancelLimitOrder` body instead (AFX-382).
 	 * @param inputs - Object with `orderIds`, an array of order object IDs to cancel.
 	 * @returns A JSON structure with the action and order IDs to be canceled.
-	 *
-	 * @example
-	 * ```typescript
-	 * const msg = limitOrders.cancelLimitOrdersMessageToSign({
-	 *   orderIds: ["0x<order1>", "0x<order2>"]
-	 * });
-	 * // user signs this JSON
-	 * ```
 	 */
 	public cancelLimitOrdersMessageToSign(inputs: { orderIds: ObjectId[] }): {
 		action: string;

--- a/src/packages/limitOrders/limitOrdersTypes.ts
+++ b/src/packages/limitOrders/limitOrdersTypes.ts
@@ -133,6 +133,11 @@ export interface ApiLimitOrdersCancelOrderTransactionBody {
 	 * The signature over those bytes, verifying user intent.
 	 */
 	signature: string;
+	/**
+	 * The order object IDs to cancel. Required: the signed message no longer
+	 * carries them, so they must travel in the body (AFX-382).
+	 */
+	orderObjectIds: string[];
 }
 
 // =========================================================================

--- a/src/packages/perpetuals/perpetualsTypes.ts
+++ b/src/packages/perpetuals/perpetualsTypes.ts
@@ -34,16 +34,20 @@ import type { CoinDecimal, CoinSymbol, CoinType } from "../coin/coinTypes";
  * that debits the specified wallet's gas pool.
  */
 export interface PerpetualsSponsorConfig {
-	/** Wallet address to use for gas pool sponsorship. */
+	/**
+	 * Wallet address to use for gas pool sponsorship. Must be the connected
+	 * wallet: af-fe now verifies the sponsor and refuses a request naming any
+	 * other address with error 2034 before it reaches the pool (AFX-382).
+	 */
 	walletAddress: SuiAddress;
 	/**
-	 * Base64 of the JSON `{"action":"SPONSOR_GAS","date":<unix seconds>}` signed
-	 * by `walletAddress`. Proves who is asking, not what for; the gas pool won't
-	 * hand out a sponsorship without it. Reusable for a day either side of
-	 * `date`, so sign once, cache it, and send it with every sponsored tx.
+	 * Base64 UTF-8 bytes of the Terms and Conditions message (see
+	 * `UserData.createTermsAndConditionsMessage`), signed once by `walletAddress`
+	 * and cached for the session. Sending this cached signature is all the gas
+	 * pool needs; it replaces the old per-tx `SPONSOR_GAS` payload (AFX-382).
 	 */
 	bytes?: string;
-	/** `walletAddress`'s signature over `bytes`. */
+	/** `walletAddress`'s signature over `bytes` (the cached T&C signature). */
 	signature?: string;
 }
 

--- a/src/packages/referrals/referrals.ts
+++ b/src/packages/referrals/referrals.ts
@@ -112,6 +112,11 @@ export class Referrals extends Caller {
 	// 	};
 	// }
 
+	/**
+	 * @deprecated af-fe no longer accepts this per-action message. Sign
+	 * `UserData.createTermsAndConditionsMessage` and pass `refCode` in the
+	 * `createReferralLink` body instead (AFX-382).
+	 */
 	public createReferralLinkMessageToSign(inputs: { refCode: string }) {
 		return {
 			action: "CREATE_REFERRAL",
@@ -120,6 +125,11 @@ export class Referrals extends Caller {
 		};
 	}
 
+	/**
+	 * @deprecated af-fe no longer accepts this per-action message. Sign
+	 * `UserData.createTermsAndConditionsMessage` and pass `refCode` in the
+	 * `setReferrer` body instead (AFX-382).
+	 */
 	public setReferrerMessageToSign(inputs: { refCode: string }) {
 		return {
 			action: "LINK_REFERRAL",

--- a/src/packages/referrals/referralsTypes.ts
+++ b/src/packages/referrals/referralsTypes.ts
@@ -130,6 +130,13 @@ export interface ApiReferralsCreateReferralLinkBody {
 	 * The signature of the message signed by the user's wallet. Required for authentication.
 	 */
 	signature: string;
+	/**
+	 * Desired referral code. Optional: when omitted the service defaults to
+	 * `ref_{walletAddress}`. The signed message no longer carries it, so it must
+	 * travel in the body (AFX-382). Note the default exceeds the 32-character
+	 * limit, so callers should always send an explicit `refCode`.
+	 */
+	refCode?: string;
 }
 
 export interface ApiReferralsCreateReferralLinkResponse {
@@ -164,6 +171,11 @@ export interface ApiReferralsSetReferrerBody {
 	 * The signature of the message signed by the referee's wallet. Required for authentication.
 	 */
 	signature: string;
+	/**
+	 * The referral code to link the referee to. Required: the signed message no
+	 * longer carries it, so it must travel in the body (AFX-382).
+	 */
+	refCode: string;
 }
 
 export interface ApiReferralsSetReferrerResponse {

--- a/src/packages/userData/userData.ts
+++ b/src/packages/userData/userData.ts
@@ -102,18 +102,43 @@ export class UserData extends Caller {
 	}
 
 	/**
-	 * Generates a simple message object that the user should sign to confirm their agreement
-	 * with the Terms and Conditions of the service.
+	 * The single message every wallet signs once per session to prove ownership.
+	 * af-fe decodes the personal-message bytes and compares this text byte for
+	 * byte, so it must stay exactly this string: no JSON wrapper, action, date,
+	 * or trailing whitespace (AFX-382).
+	 */
+	public static readonly termsAndConditionsMessage =
+		"Aftermath Terms and Conditions";
+
+	/**
+	 * Returns the canonical Terms and Conditions message to sign. Sign it as a
+	 * personal message over its UTF-8 bytes and reuse the signature for the whole
+	 * session: it is the one credential af-fe verifies for referrals, rewards,
+	 * stop/twap order datas, collateral/order history, the websocket `user`
+	 * subscription, and gas-pool sponsorship (AFX-382).
 	 *
-	 * @returns An object with an `action` property set to "SIGN_TERMS_AND_CONDITIONS".
+	 * @returns The exact string to sign.
 	 *
 	 * @example
 	 * ```typescript
-	 * const userData = new UserData();
-	 * const termsMsg = userData.createSignTermsAndConditionsMessageToSign();
-	 * console.log(termsMsg.action); // "SIGN_TERMS_AND_CONDITIONS"
-	 * // The user can sign this to show acceptance of the T&C.
+	 * const message = new UserData().createTermsAndConditionsMessage();
+	 * const { bytes, signature } = await signPersonalMessage(
+	 *   new TextEncoder().encode(message)
+	 * );
 	 * ```
+	 */
+	public createTermsAndConditionsMessage(): string {
+		return UserData.termsAndConditionsMessage;
+	}
+
+	/**
+	 * Generates a simple message object that the user should sign to confirm their agreement
+	 * with the Terms and Conditions of the service.
+	 *
+	 * @deprecated af-fe no longer accepts the `{action:...}` wrapper and rejects
+	 * it with error 2034. Sign {@link createTermsAndConditionsMessage} instead
+	 * (AFX-382).
+	 * @returns An object with an `action` property set to "SIGN_TERMS_AND_CONDITIONS".
 	 */
 	public createSignTermsAndConditionsMessageToSign(): {
 		action: string;


### PR DESCRIPTION
af-fe now verifies a single signed message and no longer passes it to the services behind it. Expose the canonical "Aftermath Terms and Conditions" string to sign, move refCode / orderObjectIds into the referral and cancel bodies, and document the sponsor block as carrying the cached T&C signature.