### PR TITLE
refac(referrals): require refCode on createReferralLink

### DIFF
--- a/.changeset/afx-382-one-signed-message.md
+++ b/.changeset/afx-382-one-signed-message.md
@@ -2,11 +2,11 @@
 "aftermath-ts-sdk": minor
 ---
 
-Move to one cached Terms and Conditions signature (AFX-382)
+Move to one cached Terms and Conditions signature
 
 af-fe now verifies a single signed message in one place and no longer passes it to the services behind it. The message is the plain string `"Aftermath Terms and Conditions"`, signed once per session and reused everywhere.
 
 - `UserData.createTermsAndConditionsMessage()` (and `UserData.termsAndConditionsMessage`) returns that canonical string to sign. The old `createSignTermsAndConditionsMessageToSign()` (JSON `{action}`) is deprecated; the backend now rejects the wrapper with error 2034.
-- Fields that used to ride inside the per-action signed message now travel in the request body: `refCode` on `createReferralLink` (optional) and `setReferrer` (required); `orderObjectIds` on `cancelLimitOrder` and `closeDcaOrder`.
+- Fields that used to ride inside the per-action signed message now travel in the request body: `refCode` on `createReferralLink` and `setReferrer`; `orderObjectIds` on `cancelLimitOrder` and `closeDcaOrder`.
 - The per-action `...MessageToSign` helpers (referrals create/link, limit cancel, dca cancel) are deprecated.
 - `PerpetualsSponsorConfig.bytes`/`signature` now carry the cached T&C signature, and `walletAddress` must be the connected wallet (docs only; shape unchanged).

--- a/src/packages/dca/dca.ts
+++ b/src/packages/dca/dca.ts
@@ -178,7 +178,7 @@ export class Dca extends Caller {
 	 *
 	 * @deprecated af-fe no longer accepts this per-action message. Sign
 	 * `UserData.createTermsAndConditionsMessage` and pass `orderObjectIds` in the
-	 * `closeDcaOrder` body instead (AFX-382).
+	 * `closeDcaOrder` body instead.
 	 * @param inputs - An object containing `orderIds`, an array of order object IDs to cancel.
 	 * @returns An object with `action: "CANCEL_DCA_ORDERS"` and the `order_object_ids`.
 	 */

--- a/src/packages/dca/dcaTypes.ts
+++ b/src/packages/dca/dcaTypes.ts
@@ -127,7 +127,7 @@ export interface ApiDcaTransactionForCloseOrderBody {
 	signature: string;
 	/**
 	 * The order object IDs to cancel. Required: the signed message no longer
-	 * carries them, so they must travel in the body (AFX-382).
+	 * carries them, so they must travel in the body.
 	 */
 	orderObjectIds: string[];
 }

--- a/src/packages/limitOrders/limitOrders.ts
+++ b/src/packages/limitOrders/limitOrders.ts
@@ -170,7 +170,7 @@ export class LimitOrders extends Caller {
 	 *
 	 * @deprecated af-fe no longer accepts this per-action message. Sign
 	 * `UserData.createTermsAndConditionsMessage` and pass `orderObjectIds` in the
-	 * `cancelLimitOrder` body instead (AFX-382).
+	 * `cancelLimitOrder` body instead.
 	 * @param inputs - Object with `orderIds`, an array of order object IDs to cancel.
 	 * @returns A JSON structure with the action and order IDs to be canceled.
 	 */

--- a/src/packages/limitOrders/limitOrdersTypes.ts
+++ b/src/packages/limitOrders/limitOrdersTypes.ts
@@ -135,7 +135,7 @@ export interface ApiLimitOrdersCancelOrderTransactionBody {
 	signature: string;
 	/**
 	 * The order object IDs to cancel. Required: the signed message no longer
-	 * carries them, so they must travel in the body (AFX-382).
+	 * carries them, so they must travel in the body.
 	 */
 	orderObjectIds: string[];
 }

--- a/src/packages/perpetuals/perpetualsTypes.ts
+++ b/src/packages/perpetuals/perpetualsTypes.ts
@@ -37,14 +37,14 @@ export interface PerpetualsSponsorConfig {
 	/**
 	 * Wallet address to use for gas pool sponsorship. Must be the connected
 	 * wallet: af-fe now verifies the sponsor and refuses a request naming any
-	 * other address with error 2034 before it reaches the pool (AFX-382).
+	 * other address with error 2034 before it reaches the pool.
 	 */
 	walletAddress: SuiAddress;
 	/**
 	 * Base64 UTF-8 bytes of the Terms and Conditions message (see
 	 * `UserData.createTermsAndConditionsMessage`), signed once by `walletAddress`
 	 * and cached for the session. Sending this cached signature is all the gas
-	 * pool needs; it replaces the old per-tx `SPONSOR_GAS` payload (AFX-382).
+	 * pool needs; it replaces the old per-tx `SPONSOR_GAS` payload.
 	 */
 	bytes?: string;
 	/** `walletAddress`'s signature over `bytes` (the cached T&C signature). */

--- a/src/packages/referrals/referrals.ts
+++ b/src/packages/referrals/referrals.ts
@@ -115,7 +115,7 @@ export class Referrals extends Caller {
 	/**
 	 * @deprecated af-fe no longer accepts this per-action message. Sign
 	 * `UserData.createTermsAndConditionsMessage` and pass `refCode` in the
-	 * `createReferralLink` body instead (AFX-382).
+	 * `createReferralLink` body instead.
 	 */
 	public createReferralLinkMessageToSign(inputs: { refCode: string }) {
 		return {
@@ -128,7 +128,7 @@ export class Referrals extends Caller {
 	/**
 	 * @deprecated af-fe no longer accepts this per-action message. Sign
 	 * `UserData.createTermsAndConditionsMessage` and pass `refCode` in the
-	 * `setReferrer` body instead (AFX-382).
+	 * `setReferrer` body instead.
 	 */
 	public setReferrerMessageToSign(inputs: { refCode: string }) {
 		return {

--- a/src/packages/referrals/referralsTypes.ts
+++ b/src/packages/referrals/referralsTypes.ts
@@ -131,12 +131,10 @@ export interface ApiReferralsCreateReferralLinkBody {
 	 */
 	signature: string;
 	/**
-	 * Desired referral code. Optional: when omitted the service defaults to
-	 * `ref_{walletAddress}`. The signed message no longer carries it, so it must
-	 * travel in the body (AFX-382). Note the default exceeds the 32-character
-	 * limit, so callers should always send an explicit `refCode`.
+	 * The referral code to create. The signed message no longer carries it, so
+	 * it travels in the body.
 	 */
-	refCode?: string;
+	refCode: string;
 }
 
 export interface ApiReferralsCreateReferralLinkResponse {
@@ -173,7 +171,7 @@ export interface ApiReferralsSetReferrerBody {
 	signature: string;
 	/**
 	 * The referral code to link the referee to. Required: the signed message no
-	 * longer carries it, so it must travel in the body (AFX-382).
+	 * longer carries it, so it must travel in the body.
 	 */
 	refCode: string;
 }

--- a/src/packages/userData/userData.ts
+++ b/src/packages/userData/userData.ts
@@ -105,7 +105,7 @@ export class UserData extends Caller {
 	 * The single message every wallet signs once per session to prove ownership.
 	 * af-fe decodes the personal-message bytes and compares this text byte for
 	 * byte, so it must stay exactly this string: no JSON wrapper, action, date,
-	 * or trailing whitespace (AFX-382).
+	 * or trailing whitespace.
 	 */
 	public static readonly termsAndConditionsMessage =
 		"Aftermath Terms and Conditions";
@@ -115,7 +115,7 @@ export class UserData extends Caller {
 	 * personal message over its UTF-8 bytes and reuse the signature for the whole
 	 * session: it is the one credential af-fe verifies for referrals, rewards,
 	 * stop/twap order datas, collateral/order history, the websocket `user`
-	 * subscription, and gas-pool sponsorship (AFX-382).
+	 * subscription, and gas-pool sponsorship.
 	 *
 	 * @returns The exact string to sign.
 	 *
@@ -136,8 +136,7 @@ export class UserData extends Caller {
 	 * with the Terms and Conditions of the service.
 	 *
 	 * @deprecated af-fe no longer accepts the `{action:...}` wrapper and rejects
-	 * it with error 2034. Sign {@link createTermsAndConditionsMessage} instead
-	 * (AFX-382).
+	 * it with error 2034. Sign {@link createTermsAndConditionsMessage} instead.
 	 * @returns An object with an `action` property set to "SIGN_TERMS_AND_CONDITIONS".
 	 */
 	public createSignTermsAndConditionsMessageToSign(): {


### PR DESCRIPTION
The service default of ref_{walletAddress} is 70 chars, over the 32-char limit, so it always fails validation. Drop the useless optional and require refCode.