### PR TITLE
revert(router): keep add-trade on the v1 serialize format

### DIFF
--- a/.changeset/router-keep-v1-serialize.md
+++ b/.changeset/router-keep-v1-serialize.md
@@ -1,0 +1,8 @@
+---
+"aftermath-ts-sdk": patch
+---
+
+Reverts `Router.addTransactionForCompleteTradeRoute()` to the v1 `serialize()`
+wire format. Only the dynamic gas endpoint requires v2; the service behind
+`transactions/add-trade` still reads v1, so that one has to move on both sides
+at once.

--- a/src/packages/router/router.ts
+++ b/src/packages/router/router.ts
@@ -288,7 +288,7 @@ export class Router extends Caller {
 			ApiRouterAddTransactionForCompleteTradeRouteBody
 		>("transactions/add-trade", {
 			...otherInputs,
-			serializedTx: await tx.toJSON(),
+			serializedTx: tx.serialize(),
 		});
 		return {
 			tx: Transaction.from(newTx),

--- a/tests/serializedTxFormat.test.ts
+++ b/tests/serializedTxFormat.test.ts
@@ -1,8 +1,10 @@
 /**
- * Transactions sent to the services must use the v2 JSON shape (`gasData`,
- * `commands`). The deprecated `Transaction.serialize()` emits the v1
- * `blockData` shape (`gasConfig`, `transactions`), which the Rust services
- * reject as invalid input.
+ * The dynamic gas service requires the v2 JSON shape (`gasData`, `commands`)
+ * and rejects the v1 `blockData` shape (`gasConfig`, `transactions`) that the
+ * deprecated `Transaction.serialize()` emits.
+ *
+ * This is per-endpoint, not global: `Router.addTransactionForCompleteTradeRoute`
+ * still sends v1, because the service behind it still reads that shape.
  *
  * ## Running
  *
@@ -13,7 +15,6 @@
 
 import { Transaction } from "@mysten/sui/transactions";
 import { DynamicGas } from "../src/general/dynamicGas/dynamicGas";
-import { Router } from "../src/packages/router/router";
 
 const SENDER =
 	"0x0000000000000000000000000000000000000000000000000000000000000abc";
@@ -67,25 +68,6 @@ describe("DynamicGas.getUseDynamicGasForTx", () => {
 			walletAddress: SENDER,
 			gasCoinType: "0x2::sui::SUI",
 		});
-
-		expectV2(body().serializedTx);
-	});
-});
-
-describe("Router.addTransactionForCompleteTradeRoute", () => {
-	it("sends the transaction as v2 JSON", async () => {
-		const router = new Router();
-		const body = captureBody(router, {
-			tx: await buildTx().toJSON(),
-			coinOutId: undefined,
-		});
-
-		await router.addTransactionForCompleteTradeRoute({
-			tx: buildTx(),
-			walletAddress: SENDER,
-			completeRoute: undefined as never,
-			slippage: 0.01,
-		} as never);
 
 		expectV2(body().serializedTx);
 	});


### PR DESCRIPTION
The v2 switch was applied to `Router.addTransactionForCompleteTradeRoute` as well as dynamic gas, but only the dynamic gas service needed it. The service behind `transactions/add-trade` still reads the v1 `blockData` shape, so sending it `toJSON()` would have broken a working path. That endpoint has to move on both sides at once.

The format test now covers dynamic gas only, and says why it is per-endpoint rather than global.