### PR TITLE
fix(perps): align websocket price payload types

### DIFF
--- a/.changeset/ws-market-mark-price-reviver.md
+++ b/.changeset/ws-market-mark-price-reviver.md
@@ -1,0 +1,11 @@
+---
+"aftermath-ts-sdk": patch
+---
+
+Add `markPrice` to the perpetuals market websocket payload and correct the
+oracle websocket `bookPrice` type to `number | undefined`.
+
+The service sends JSON `null` when the raw orderbook midpoint is unavailable,
+but the SDK JSON reviver converts that value to `undefined`. Market and oracle
+streams expose the same position-marking quantity, sampled independently per
+frame.

--- a/src/packages/perpetuals/perpetualsTypes.ts
+++ b/src/packages/perpetuals/perpetualsTypes.ts
@@ -5224,6 +5224,16 @@ export interface PerpetualsWsUpdatesMarketCandlesSubscriptionType {
 }
 
 /**
+ * Websocket payload for market state updates.
+ */
+export interface PerpetualsWsUpdatesMarketPayload extends PerpetualsMarketData {
+	/**
+	 * Current mark price used for position PnL and liquidation calculations.
+	 */
+	markPrice: number;
+}
+
+/**
  * Websocket payload for oracle price updates.
  */
 export interface PerpetualsWsUpdatesOraclePayload {
@@ -5239,11 +5249,11 @@ export interface PerpetualsWsUpdatesOraclePayload {
 	 */
 	markPrice: number;
 	/**
-	 * Raw orderbook mid price, or `null` when either side of the book is empty.
-	 * Nullable where `markPrice` is not: mark falls back to the index price
-	 * upstream, whereas a raw mid has none.
+	 * Raw orderbook mid price. The wire sends JSON `null` when either side of
+	 * the book is empty; the SDK JSON reviver converts that value to `undefined`.
+	 * Unlike the raw mid, `markPrice` falls back to the index price upstream.
 	 */
-	bookPrice: number | null;
+	bookPrice: number | undefined;
 }
 
 /**
@@ -5364,7 +5374,7 @@ export interface PerpetualsWsUpdatesSubscriptionMessage {
 export type PerpetualsWsUpdatesResponseMessage =
 	| {
 			/** Latest market update, when present. */
-			market: PerpetualsMarketData;
+			market: PerpetualsWsUpdatesMarketPayload;
 	  }
 	| {
 			/** Latest user or account update, when present. */

--- a/tests/packages/perpetuals/ws.test.ts
+++ b/tests/packages/perpetuals/ws.test.ts
@@ -1,0 +1,94 @@
+import type { PerpetualsWsUpdatesResponseMessage } from "@sdk/types";
+import { Perpetuals } from "@test/packages/perpetuals/fixturesDomain.js";
+
+type MockWsCallback = (event: unknown) => void;
+
+class MockWS {
+	static readonly OPEN = 1;
+	static readonly CLOSED = 3;
+	readonly listeners: Record<string, MockWsCallback[]> = {};
+	readonly sent: string[] = [];
+	readyState = MockWS.OPEN;
+	readonly url: string;
+
+	constructor(url: string) {
+		this.url = url;
+	}
+
+	addEventListener(event: string, callback: MockWsCallback) {
+		const callbacks = this.listeners[event] ?? [];
+		callbacks.push(callback);
+		this.listeners[event] = callbacks;
+	}
+
+	removeEventListener() {
+		// The fixture does not need listener removal.
+	}
+
+	send(data: string) {
+		this.sent.push(data);
+	}
+
+	close() {
+		this.readyState = MockWS.CLOSED;
+	}
+
+	triggerMessage(data: string) {
+		for (const callback of this.listeners.message ?? []) {
+			callback({ data });
+		}
+	}
+}
+
+describe("Perpetuals updates websocket", () => {
+	const originalWebSocket = globalThis.WebSocket;
+
+	afterEach(() => {
+		globalThis.WebSocket = originalWebSocket;
+	});
+
+	it("preserves market mark price and revives a null oracle book price", () => {
+		globalThis.WebSocket = MockWS as unknown as typeof WebSocket;
+		const messages: PerpetualsWsUpdatesResponseMessage[] = [];
+		const perps = new Perpetuals({ baseUrl: "https://sdk.test" });
+		const { ws } = perps.openUpdatesWebsocketStream({
+			onMessage: (message: PerpetualsWsUpdatesResponseMessage) => {
+				messages.push(message);
+			},
+		});
+		const mockWs = ws as unknown as MockWS;
+
+		mockWs.triggerMessage(
+			JSON.stringify({
+				market: {
+					objectId: "0xmarket",
+					markPrice: 81_000,
+				},
+			})
+		);
+		mockWs.triggerMessage(
+			JSON.stringify({
+				oracle: {
+					marketId: "0xmarket",
+					basePrice: 80_990,
+					collateralPrice: 1,
+					markPrice: 81_000,
+					bookPrice: null,
+				},
+			})
+		);
+
+		expect(messages[0]).toEqual({
+			market: { objectId: "0xmarket", markPrice: 81_000 },
+		});
+		expect(messages[1]).toEqual({
+			oracle: {
+				marketId: "0xmarket",
+				basePrice: 80_990,
+				collateralPrice: 1,
+				markPrice: 81_000,
+				bookPrice: undefined,
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- type `market.markPrice` on perpetuals WebSocket updates
- correct `oracle.bookPrice` to `number | undefined` because the SDK reviver converts wire `null`
- add a behavioral WebSocket regression test

## Verification

- `bun run test:ci` — 75 suites, 681 tests passed
- `bun run test:surface:strict` — 76/76 source modules coverage-backed
- `bun run typecheck:tests`
- `bun run docs:audit:strict` — 3179/3179 symbols documented
- `bun run test:release`
- `bun run build`
- targeted Ultracite check on changed TypeScript files

## Deployment note

Production frames were still emitting the old field set at 2026-09-03 17:20 UTC. This PR aligns the SDK with the announced additive schema; the backend rollout remains separate.
