### PR TITLE
feat(pools): call the versioned pools/v1 transaction endpoints

### DIFF
--- a/.changeset/pools-v1-endpoint.md
+++ b/.changeset/pools-v1-endpoint.md
@@ -1,0 +1,5 @@
+---
+"aftermath-ts-sdk": patch
+---
+
+Point pool creation at the versioned `pools/v1/transactions/*` endpoints. `getPublishLpCoinTransaction` and `getCreatePoolTransaction` now call the v1 paths, which build against the v3 AMM contract, while the unversioned endpoints stay on the current live functions so existing integrations keep working.

--- a/src/packages/pools/pools.ts
+++ b/src/packages/pools/pools.ts
@@ -301,7 +301,7 @@ export class Pools extends Caller {
 		const { tx } = await this.fetchApiTxObject<
 			ApiPublishLpCoinBody,
 			ApiTransactionResponse
-		>("transactions/publish-lp-coin", inputs);
+		>("v1/transactions/publish-lp-coin", inputs);
 		return tx;
 	}
 
@@ -345,7 +345,7 @@ export class Pools extends Caller {
 		const { tx } = await this.fetchApiTxObject<
 			ApiCreatePoolBody,
 			ApiTransactionResponse
-		>("transactions/create-pool", inputs);
+		>("v1/transactions/create-pool", inputs);
 		return tx;
 	}
 


### PR DESCRIPTION
Point getPublishLpCoinTransaction and getCreatePoolTransaction at pools/v1/transactions/*, which build against the v3 AMM contract. The unversioned endpoints stay on the current live functions so existing integrations keep working through a deprecation window.